### PR TITLE
Implemented Exception Handling for deleteAll Method in FlutterSecureStoragePlugin

### DIFF
--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
@@ -186,8 +186,8 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
                    try {
                        secureStorage.deleteAll();
                        result.success("Data has been reset");
-                   } catch (Exception _e) {
-                       handleException(_e);
+                   } catch (Exception ex) {
+                       handleException(ex);
                    }
                 } else {
                     handleException(e);

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
@@ -183,8 +183,12 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
                 }
             } catch (Exception e) {
                if (!(e instanceof FileNotFoundException) && resetOnError) {
-                    secureStorage.deleteAll();
-                    result.success("Data has been reset");
+                   try {
+                       secureStorage.deleteAll();
+                       result.success("Data has been reset");
+                   } catch (Exception _e) {
+                       handleException(_e);
+                   }
                 } else {
                     handleException(e);
                 }


### PR DESCRIPTION
Fixes have been made to the `secureStorage.deleteAll()` method in the FlutterSecureStoragePlugin.
 Previously, this method could throw an exception but was not properly handling it. This was causing compile errors.

